### PR TITLE
Add stop-on-error option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Příklad:
 Argumenty:
 
 ```
-usage: test.py [-h] [--bonus] [--valgrind] [--no-color] P
+usage: test.py [-h] [--bonus] [--valgrind] [--no-color] [--stop-on-error] P
 
 Tester 2. IZP projektu
 
@@ -37,8 +37,9 @@ positional arguments:
   P           Cesta k programu (napriklad: setcal)
 
 optional arguments:
-  -h, --help  show this help message and exit
-  --bonus     Kontrola bonusoveho reseni
-  --valgrind  Kontrola chyb pomoci valgrindu
-  --no-color  Vystup bez barev
+  -h, --help      show this help message and exit
+  --bonus         Kontrola bonusoveho reseni
+  --valgrind      Kontrola chyb pomoci valgrindu
+  --no-color      Vystup bez barev
+  --stop-on-error Vypnout tester kdyz je chyba
 ```

--- a/test.py
+++ b/test.py
@@ -28,10 +28,11 @@ def detect_valgrind():
         return False
 
 class Tester:
-    def __init__(self, program_name, valgrind):
+    def __init__(self, program_name, valgrind, stop_on_error):
         self.program_name = './' + program_name
         self.test_count = 0
         self.pass_count = 0
+        self.stop_on_error = stop_on_error
         self.valgrind = valgrind
 
     def check_valgrind(self, args):
@@ -131,6 +132,12 @@ class Tester:
 
         if self.valgrind:
             self.check_valgrind(args)
+            
+        if error and self.stop_on_error:
+            if valgrind:
+                os.remove(VALGRIND_LOG)
+            
+            exit();
 
     def print_stats(self):
         print('Uspesnost: {}/{} ({:.2f}%)'.format(self.pass_count, self.test_count, (self.pass_count / self.test_count) * 100))
@@ -142,6 +149,7 @@ if __name__ == '__main__':
     parser.add_argument('--bonus', dest='bonus', action='store_true', help='Kontrola bonusoveho reseni')
     parser.add_argument('--valgrind', dest='valgrind', action='store_true', help='Kontrola chyb pomoci valgrindu')
     parser.add_argument('--no-color', dest='color', action='store_false', help='Vystup bez barev')
+    parser.add_argument('--stop-on-error', dest='stop_on_error', action='store_true', help='Vypnout tester kdyz je chyba')
     args = parser.parse_args()
 
     if not args.color:
@@ -153,8 +161,8 @@ if __name__ == '__main__':
     if valgrind:
         valgrind = detect_valgrind()
 
-    t1 = Tester(args.prog, valgrind)
-    t2 = Tester(args.prog, valgrind)
+    t1 = Tester(args.prog, valgrind, args.stop_on_error)
+    t2 = Tester(args.prog, valgrind, args.stop_on_error)
 
     # Testy ze zadani
     t1.test('Test ze zadani #1 (sets.txt)', ['tests/assignment/sets.txt'], 'tests/assignment/sets_res.txt')


### PR DESCRIPTION
It just stop the tester on the first error so we can focus on fixing errors one by one, not to scroll up hundred lines to see the error